### PR TITLE
Updating xpath compile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-instapy==0.6.11
+instapy==0.6.12

--- a/xpath_compile.py
+++ b/xpath_compile.py
@@ -35,6 +35,11 @@ xpath["dismiss_notification_offer"] = {
     "dismiss_elem_loc": "//button[text()='Not Now']",
 }
 
+xpath["dissmiss_save_information"] = {
+    "offer_elem_loc": "//*[contains(text(), 'Save Info')]",
+    "dismiss_elem_loc": "//*[contains(text(), 'Not Now')]",
+}
+
 xpath["extract_information"] = {
     "close_overlay": "//div/div[@role='dialog']",
     "one_pic_elem": "//section/main/article/div[1]/div/div[10]/div[3]/a/div",
@@ -144,6 +149,7 @@ xpath["like_comment"] = {
 xpath["like_image"] = {
     "like": "//section/span/button/div/span[*[local-name()='svg']/@aria-label='Like']",
     "unlike": "//section/span/button/div/span[*[local-name()='svg']/@aria-label='Unlike']",
+    "play": "//*/span[contains(@aria-label, 'Play')]",
 }
 
 xpath["like_from_image"] = {


### PR DESCRIPTION
Hello 

this fix is intended to solve the outdated `xpath_compile.py` file, 
Since docker file is replacing the one under `/usr/local/lib/python3.7/site-packages/instapy/` last changes then are lost.
Further details in #5856 (https://github.com/timgrossmann/InstaPy/issues/5856)

stack trace:

```python
Traceback (most recent call last):
  File "docker_quickstart.py", line 138, in <module>
    bot.like_by_locations([random.choice(locations)], amount=4, skip_top_posts=True)
  File "/usr/local/lib/python3.7/site-packages/instapy/instapy.py", line 1531, in like_by_locations
    liked_img,
  File "/usr/local/lib/python3.7/site-packages/instapy/like_util.py", line 759, in like_image
    play_xpath = read_xpath(like_image.__name__, "play")
  File "/usr/local/lib/python3.7/site-packages/instapy/xpath.py", line 5, in read_xpath
    return xpath[function_name][xpath_name]
KeyError: 'play'
``