### PR TITLE
Dockerfile for Raspberry Pi [armhf]

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,0 +1,30 @@
+FROM python:3.7-slim-buster
+WORKDIR /code
+RUN sed -i "s#deb http://deb.debian.org/debian buster main#deb http://deb.debian.org/debian buster main contrib non-free#g" /etc/apt/sources.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends --no-install-suggests \
+  bzip2 \
+  wget \
+  gcc \
+  g++ \
+  firefox-esr \
+  # cryptography build dependencies
+  libffi-dev \
+  libssl-dev \
+  rustc \
+  cargo \
+  && wget -O '/tmp/requirements.txt' https://raw.githubusercontent.com/InstaPy/instapy-docker/master/requirements.txt \
+  && pip install --no-cache-dir -U -r /tmp/requirements.txt \
+  && apt-get purge -y --auto-remove \
+  gcc \
+  g++ \
+  bzip2 \
+  rustc \
+  cargo \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/requirements.txt \
+  # Disabling geckodriver log file
+  && sed -i "s#browser = webdriver.Firefox(#browser = webdriver.Firefox(service_log_path=os.devnull,#g" /usr/local/lib/python3.7/site-packages/instapy/browser.py \
+  # Fix webdriverdownloader not handling asc files
+  && sed -i "s#bitness in name]#bitness in name and name[-3:] != 'asc' ]#g" /usr/local/lib/python3.7/site-packages/webdriverdownloader/webdriverdownloader.py
+CMD ["python", "docker_quickstart.py"]


### PR DESCRIPTION
The existing Dockerfile doesn't support Raspberry Pi OS, mainly due to Firefox amd64 binary being explicitly downloaded.
This Dockerfile installs it from apt (`firefox-esr=78.9.0esr-1~deb10u1+rpi1`) + fixes some build dependencies for the `cryptography` package.